### PR TITLE
Add install step to github actions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,5 +24,5 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    
+    - run: npm install
     - run: npm test


### PR DESCRIPTION
Your log says `sh: 1: react-scripts: not found` because you aren't installing your dependencies.

Looks like your action is missing the install step. 

Odd, because it should be there by default when you create the action.